### PR TITLE
Generate HTTP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Sample service to test Spring features.
 
 ## Changelog
 
+*In the following section the top activity is the latest one.*
+
+- Add Gradle task `buildClients` to build Python and TypeScript HTTP clients.
+  Sources are generated within the `build/client` folder.
+  For generator options see pages
+  [Documentation for the python Generator](https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/python.md)
+  and
+  [Documentation for the typescript-axios Generator](https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/typescript-axios.md)
 - Implement *API first* approach using
   [OpenAPI Generator Gradle Plugin](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-gradle-plugin/README.adoc).
   The plugin generates Java interfaces that represent the API and classes to

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
+
 plugins {
 	id 'org.springframework.boot' version '2.7.0'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
@@ -99,3 +101,22 @@ checkstyle {
 }
 checkstyleMain.source = "src/main/java"
 checkstyleTest.source = "src/test/java"
+
+// OPENAPI CLIENT GENERATOR
+task buildTypeScriptClient(type: GenerateTask){
+  generatorName = "typescript-axios"
+  inputSpec = "$rootDir/src/main/resources/openapi/openapi.yaml".toString()
+  outputDir = "$buildDir/client/typescript-axios".toString()
+  generateApiTests = false
+  generateModelTests = false
+}
+
+task buildPythonClient(type: GenerateTask){
+  generatorName = "python"
+  inputSpec = "$rootDir/src/main/resources/openapi/openapi.yaml".toString()
+  outputDir = "$buildDir/client/python".toString()
+  generateApiTests = false
+  generateModelTests = false
+}
+
+task buildClients(dependsOn: ['buildTypeScriptClient', 'buildPythonClient'])


### PR DESCRIPTION
Add the `buildClients` Gradle task that creates Python and TypeScript
HTTP clients to call the endpoints exposed by the service.