### PR TITLE
Make integrationTest independent of test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
   id 'org.openapi.generator' version '6.0.0'
   id 'org.sonarqube' version '3.4.0.2513'
   id 'idea'
+//  id 'org.barfuin.gradle.taskinfo' version '1.4.0'
 }
 
 group = 'it.tccr'
@@ -90,6 +91,9 @@ task integrationTest(type: Test, description: 'Runs integration tests.', group: 
   }
 }
 
+check.dependsOn integrationTest
+check.finalizedBy jacocoTestReport
+
 // OPENAPI GENERATOR
 task cleanOpenApiGenerate(type: Delete, description: 'Deletes OpenAPI generated files') {
   delete fileTree(dir: "$rootDir/src/gen/java".toString(), exclude: "**/.openapi-generator-ignore")
@@ -122,9 +126,6 @@ openApiGenerate {
 
 jacoco {
   toolVersion = '0.8.7'
-}
-tasks.withType(Test) {
-  finalizedBy jacocoTestReport
 }
 
 ext {


### PR DESCRIPTION
Adjust Gradle build file to allow running integration tests without the
need of running test before.